### PR TITLE
Improve coroutine use

### DIFF
--- a/app/src/main/java/com/karumi/kataloginlogoutkotlin/Presenter.kt
+++ b/app/src/main/java/com/karumi/kataloginlogoutkotlin/Presenter.kt
@@ -1,18 +1,21 @@
 package com.karumi.kataloginlogoutkotlin
 
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.cancel
-import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import kotlin.coroutines.CoroutineContext
 
 class Presenter(
     private val logInLogOutKata: LogInLogOutKata,
-    private val view: View
+    private val view: View,
+    private val context: CoroutineContext = Dispatchers.Default
 ) : CoroutineScope by MainScope() {
 
     fun onLogInButtonTap(username: String, password: String) = launch {
-        val lotInResult = coroutineScope { logInLogOutKata.logIn(username, password) }
+        val lotInResult = withContext(context) { logInLogOutKata.logIn(username, password) }
         lotInResult.fold(
             {
                 when (it) {
@@ -28,7 +31,7 @@ class Presenter(
     }
 
     fun onLogOutButtonTap() = launch {
-        val logOutResult = coroutineScope { logInLogOutKata.logOut() }
+        val logOutResult = withContext(context) { logInLogOutKata.logOut() }
         if (logOutResult) {
             view.hideLogOutForm()
             view.showLogInForm()

--- a/app/src/test/java/com/karumi/kataloginlogoutkotlin/PresenterTest.kt
+++ b/app/src/test/java/com/karumi/kataloginlogoutkotlin/PresenterTest.kt
@@ -7,7 +7,6 @@ import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.setMain
 import org.junit.Before
@@ -15,7 +14,6 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
-import java.util.concurrent.Executors
 
 @RunWith(MockitoJUnitRunner::class)
 class PresenterTest {
@@ -34,61 +32,56 @@ class PresenterTest {
 
     @Before
     fun setUp() {
-        Dispatchers.setMain(Executors.newSingleThreadExecutor().asCoroutineDispatcher())
-        presenter = Presenter(kata, view)
+        Dispatchers.setMain(Dispatchers.Unconfined)
+        presenter = Presenter(kata, view, Dispatchers.Unconfined)
     }
 
     @Test
-    fun `should show invalid credentials error if the log in process returns InvalidCredentials`() =
-        runBlocking {
-            givenTheLogInProcessReturns(InvalidCredentials.left())
+    fun `should show invalid credentials error if the log in process returns InvalidCredentials`() {
+        givenTheLogInProcessReturns(InvalidCredentials.left())
 
-            presenter.onLogInButtonTap(ANY_USERNAME, ANY_PASS).join()
+        presenter.onLogInButtonTap(ANY_USERNAME, ANY_PASS)
 
-            verify(view).showError(R.string.log_in_error_message)
-        }
-
-    @Test
-    fun `should show an invalid username error if the log in process returns InvalidUsername`() =
-        runBlocking {
-            givenTheLogInProcessReturns(InvalidUsername.left())
-
-            presenter.onLogInButtonTap(ANY_USERNAME, ANY_PASS).join()
-
-            verify(view).showError(R.string.invalid_username_error_message)
-        }
+        verify(view).showError(R.string.log_in_error_message)
+    }
 
     @Test
-    fun `should show a could not perform log out error if the log out process fails`() =
-        runBlocking {
-            givenTheLogOutProcessReturns(false)
+    fun `should show an invalid username error if the log in process returns InvalidUsername`() {
+        givenTheLogInProcessReturns(InvalidUsername.left())
 
-            presenter.onLogOutButtonTap().join()
+        presenter.onLogInButtonTap(ANY_USERNAME, ANY_PASS)
 
-            verify(view).showError(R.string.log_out_error_message)
-        }
-
-    @Test
-    fun `should hide the login form & show the logout form if the login process finishes`() =
-        runBlocking {
-            givenTheLogInProcessReturns(ANY_USERNAME.right())
-
-            presenter.onLogInButtonTap(ANY_USERNAME, ANY_PASS).join()
-
-            verify(view).hideLogInForm()
-            verify(view).showLogOutForm()
-        }
+        verify(view).showError(R.string.invalid_username_error_message)
+    }
 
     @Test
-    fun `should hide the logout form and show the login form if the logout process finishes`() =
-        runBlocking {
-            givenTheLogOutProcessReturns(true)
+    fun `should show a could not perform log out error if the log out process fails`() {
+        givenTheLogOutProcessReturns(false)
 
-            presenter.onLogOutButtonTap().join()
+        presenter.onLogOutButtonTap()
 
-            verify(view).hideLogOutForm()
-            verify(view).showLogInForm()
-        }
+        verify(view).showError(R.string.log_out_error_message)
+    }
+
+    @Test
+    fun `should hide the login form & show the logout form if the login process finishes`() {
+        givenTheLogInProcessReturns(ANY_USERNAME.right())
+
+        presenter.onLogInButtonTap(ANY_USERNAME, ANY_PASS)
+
+        verify(view).hideLogInForm()
+        verify(view).showLogOutForm()
+    }
+
+    @Test
+    fun `should hide the logout form and show the login form if the logout process finishes`() {
+        givenTheLogOutProcessReturns(true)
+
+        presenter.onLogOutButtonTap()
+
+        verify(view).hideLogOutForm()
+        verify(view).showLogInForm()
+    }
 
     private fun givenTheLogOutProcessReturns(result: Boolean) {
         runBlocking { whenever(kata.logOut()).thenReturn(result) }


### PR DESCRIPTION
`coroutineScope` function runs the coroutine in the same context it was created, that is, the main thread so we are now using a different function to run that code in background: `withContext`. In test time we just tell the presenter to run everything in an `Unconfined` dispatcher, that is, in the same thread it was called. No need for `runBlocking` anymore :)